### PR TITLE
Add link to the 2.3 release of the desktop client

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -90,11 +90,21 @@ clients.
   <https://doc.owncloud.com/branded_clients/Building_Branded_ownCloud_Clients.pdf>`_)
   
 
+---------------------------------------------------
+ownCloud Desktop Client 2.3, Latest Stable Releases
+---------------------------------------------------
+
+The *latest* ownCloud desktop sync client release, suitable for production use.
+
+* `ownCloud Desktop Client Manual <https://doc.owncloud.com/desktop/2.3/>`_ 
+  (`Download PDF 
+  <https://doc.owncloud.com/desktop/2.3/ownCloudClientManual.pdf>`_)
+
 ---------------------------
 ownCloud Desktop Client 2.2
 ---------------------------
 
-The *latest* ownCloud desktop sync client release, suitable for production use.
+The previous ownCloud desktop sync client release, suitable for production use.
 
 * `ownCloud Desktop Client Manual <https://doc.owncloud.com/desktop/2.2/>`_ 
   (`Download PDF 


### PR DESCRIPTION
This PR:

- Adds a reference to the 2.3 release of the desktop client

### References

owncloud/documentation/issues/2925