### PR TITLE
Fix the latest release information

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -35,20 +35,20 @@ This documents the *latest production* version of ownCloud.
   (`Download PDF 
   <https://doc.owncloud.com/server/10.0/ownCloudDeveloperManual.pdf>`_)
 
-----------------------------------------
-Previous Stable Release  - ownCloud 10.0 
-----------------------------------------
+---------------------------------------
+Previous Stable Release  - ownCloud 9.1 
+---------------------------------------
 
 This documents the *previous production* version of ownCloud.
 
-* `User Manual <https://doc.owncloud.com/server/10.0/user_manual/>`_ (`Download 
-  PDF <https://doc.owncloud.com/server/10.0/ownCloud_User_Manual.pdf>`_)
-* `Administration Manual <https://doc.owncloud.com/server/10.0/admin_manual/>`_ 
+* `User Manual <https://doc.owncloud.com/server/9.1/user_manual/>`_ (`Download 
+  PDF <https://doc.owncloud.com/server/9.1/ownCloud_User_Manual.pdf>`_)
+* `Administration Manual <https://doc.owncloud.com/server/9.1/admin_manual/>`_ 
   (`Download PDF   
-  <https://doc.owncloud.com/server/10.0/ownCloud_Server_Administration_Manual.pdf>`_)
-* `Developer Manual <https://doc.owncloud.com/server/10.0/developer_manual/>`_ 
+  <https://doc.owncloud.com/server/9.1/ownCloud_Server_Administration_Manual.pdf>`_)
+* `Developer Manual <https://doc.owncloud.com/server/9.1/developer_manual/>`_ 
   (`Download PDF 
-  <https://doc.owncloud.com/server/10.0/ownCloudDeveloperManual.pdf>`_)
+  <https://doc.owncloud.com/server/9.1/ownCloudDeveloperManual.pdf>`_)
 
 ====================
 Enterprise Appliance
@@ -105,6 +105,21 @@ Older ownCloud Server Releases
 
 This documents the *older* ownCloud releases. Users are encouraged to 
 upgrade to the latest production release.
+
+------------
+ownCloud 9.0
+------------
+
+This documents the *previous production* version of ownCloud.
+
+* `User Manual <https://doc.owncloud.com/server/9.0/user_manual/>`_ (`Download
+  PDF <https://doc.owncloud.com/server/9.0/ownCloud_User_Manual.pdf>`_)
+* `Administration Manual <https://doc.owncloud.com/server/9.0/admin_manual/>`_
+  (`Download PDF
+  <https://doc.owncloud.com/server/9.0/ownCloud_Server_Administration_Manual.pdf>`_)
+* `Developer Manual <https://doc.owncloud.com/server/9.0/developer_manual/>`_
+  (`Download PDF
+  <https://doc.owncloud.com/server/9.0/ownCloudDeveloperManual.pdf>`_)
 
 ------------
 ownCloud 8.2


### PR DESCRIPTION
There was a mistake made in the previous PR to update the latest release. This PR corrects that. It also adds the older releases to the older releases section so that they're not forgotten nor overlooked.